### PR TITLE
Add promote to Maven gcloud plugin config.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
                 <artifactId>gcloud-maven-plugin</artifactId>
                 <version>2.0.9.88.v20151125</version>
                 <configuration>
+                    <promote>true</promote>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This will set the version to defauld and suppress a warning when running
"mvn gcloud:deploy".